### PR TITLE
Fix babel config for rebundling

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,5 +2,6 @@
     "presets": ["es2015"],
     "plugins": [
         "add-module-exports"
-    ]
+    ],
+    "ignore": ["dist/**/*.js"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ bridge/
 .ruby-version
 .gitattributes
 test/html/build.js
+lib-es5/
 

--- a/.npmignore
+++ b/.npmignore
@@ -2,9 +2,9 @@ npm-debug.log
 dist/bundle/
 docs/
 demo-hls.js/
-example/build.js
 toolkit/
 bridge/
 .ruby-version
 test/html/build.js
+example/app/build.js
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,7 @@ module.exports = function (grunt) {
                                     false),
             example_app: makeBrowserifyTask("example/app/main.js", 
                                             "example/app/build.js",
-                                            "ExampleApp", false)
+                                            "ExampleApp", true)
         }
     });
 

--- a/circle.yml
+++ b/circle.yml
@@ -37,6 +37,7 @@ deployment:
         branch: /^(?!(?:dev|master)$).+$/
         commands:
             # Upload dist
+            - npm run babel
             - grunt browserify:bundle
             - grunt browserify:wrapper
 
@@ -77,6 +78,7 @@ deployment:
             - toolkit/set_version.rb --version $(toolkit/current_version.rb --beta ${CIRCLE_BUILD_NUM})
 
             # Generate dist
+            - npm run babel
             - grunt browserify:bundle
             - grunt browserify:wrapper
 
@@ -158,6 +160,7 @@ deployment:
             - rm -rf dist
 
             # Generate dist
+            - npm run babel
             - grunt browserify:bundle
             - grunt browserify:wrapper
 

--- a/example/app/index.html
+++ b/example/app/index.html
@@ -5,8 +5,10 @@
         <script src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.4.9/d3.min.js"> </script>
 
         <script>
+            window._ENVIRONMENT_ = 'development';
             window._DEBUG_ = true;
             window._TEST_ = false;
+            window._MOBILE_ = false;
             window.streamrootConfig = {
                 p2pConfig:{
                     streamrootKey: "ry-v7xuywnt",

--- a/example/app/main.js
+++ b/example/app/main.js
@@ -1,4 +1,4 @@
-import HlsjsWrapper from '../../dist/wrapper/hlsjs-p2p-wrapper-common';
+import HlsjsWrapper from '../../lib-es5/hlsjs-p2p-wrapper';
 import Hls from 'hls.js';
 
 window.CreatePlayer = function(hlsjsConfig, p2pConfig) {

--- a/example/app/main.js
+++ b/example/app/main.js
@@ -1,9 +1,9 @@
-import HlsjsWrapper from '../../lib-es5/hlsjs-p2p-wrapper';
+import HlsjsP2PWrapper from '../../dist/wrapper/hlsjs-p2p-wrapper';
 import Hls from 'hls.js';
 
 window.CreatePlayer = function(hlsjsConfig, p2pConfig) {
 
-	return (new HlsjsWrapper(Hls)).createPlayer(hlsjsConfig || {}, p2pConfig);
+	return (new HlsjsP2PWrapper(Hls)).createPlayer(hlsjsConfig || {}, p2pConfig);
 
 }
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "start": "node_modules/.bin/static",
     "debug": "iron-mocha --require mochahook",
     "preinstall": "npm run clean",
-    "postinstall": "./update_demo.rb"
+    "postinstall": "./update_demo.rb",
+    "babel": "babel lib --out-dir lib-es5"
   },
   "browserify": {
     "transform": [
@@ -34,6 +35,7 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
+    "babel-cli": "^6.10.1",
     "babel-core": "^6.7.7",
     "babel-eslint": "^6.0.4",
     "babel-plugin-add-module-exports": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -21,11 +21,6 @@
     "postinstall": "./update_demo.rb",
     "babel": "babel lib --out-dir lib-es5"
   },
-  "browserify": {
-    "transform": [
-      "babelify"
-    ]
-  },
   "dependencies": {
     "hls.js": "0.5.39",
     "lodash.assigninwith": "^4.0.7",
@@ -59,6 +54,7 @@
     "node-static": "^0.7.7",
     "should": "^9.0.0",
     "uglifyify": "^3.0.1",
+    "webpack": "^1.13.1",
     "xhr-shaper": "^0.2.1"
   }
 }


### PR DESCRIPTION
* Workaround of our bundling issues by shipping a proper ES5 compatible lib and import that directly into the app (see `example/app/main.js`)

* Fix for issue with this package when used in a babel toolchain (babelizing its deps will break some code that can't run in babel imposed "use strict" mode

CHANGES:

* removed babelify transform from package (otherwise any downstream toolchain will try to babelize our distro which will break it)
* added "example app" in order to QA downstream bundling of this package
* added babelizing script on our side to be run at deploy time. thus we can ship ES5 code as source-tree instead of pre-built

ALTERNATIVE SOLUTIONS:

* factorize a package.json and run publish on that for the wrapper distro (exactly like we do for bundle)

* keep the babelify transform config on package.json. means we can keep just only shipping the ES6 
source-tree (but then our `main` should also actually point to it)

OR

* have our main point to ES5 source tree (makes it available for anybody even without an ES6 toolchain)

In general shipping a source tree is always great for de-duping deps, so downstream consumers can optimize their builds best

TODO:

- [ ] factorize package.json for wrapper, yes/no?
- [ ] if above yes, point "main package" main to ES5 or ES6 source tree?