### PR TITLE
copy lib folder into wrapper dist folder 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -187,6 +187,11 @@ deployment:
                                             --name $WRAPPER_NAME
                                             -o dist/wrapper/package.json
 
+            # Copy sources (lib) into wrapper dist folder
+            # We ship the sources to be able to access private API
+            # for integration testing usage
+            - cp -R lib dist/wrapper/
+
             # Publish
             - npm publish dist/bundle
             - npm publish dist/wrapper


### PR DESCRIPTION
so that it gets published along with the package. we need this to access private API for integration test + examples