### PR TITLE
Publish npm dist as rc when comming from master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog's template come from [keepachangelog.com](http://keepachangelog.com/). When editing this document, please follow the convention specified there.
 
 ## [Dev]
+### Changed
+- Publish npm dist as rc when comming from master
 
 ## [Unreleased]
 

--- a/circle.yml
+++ b/circle.yml
@@ -193,8 +193,8 @@ deployment:
             - cp -R lib dist/wrapper/
 
             # Publish
-            - npm publish dist/bundle
-            - npm publish dist/wrapper
+            - npm publish dist/bundle --tag rc
+            - npm publish dist/wrapper --tag rc
 
             # Upload version
             - toolkit/upload_to_s3.rb --bucket $S3_PREPROD_BUCKET


### PR DESCRIPTION
Currently we publish dists as latest when coming from master.
This PR will tag those dists as `rc` (preprod dist).
And we will have to make them as latest dist once it's QA tested.