### PR TITLE
From our "private" package (it is never published) we should point to ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "streamroot-hlsjs-p2p-wrapper",
   "version": "3.7.0-beta.0",
-  "main": "lib/streamroot-wrapper.js",
+  "main": "./lib/hlsjs-p2p-wrapper-private.js",
   "homepage": "www.streamroot.io",
   "author": {
     "name": "streamroot",


### PR DESCRIPTION
a) a file that actually exists
b) it should be the private wrapper API so that we use this conveniently for dev/testing modes
c) this fix is also needed to make this package work in context of npm link