### PR TITLE
P2P on/off API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 
 ## [Dev]
 
+### Added
+- p2pDownloadOn and p2pUploadOn properties on public API
+
 ## [Unreleased]
 
 ## [3.6.8] - 2016-08-19

--- a/lib/hlsjs-p2p-wrapper.js
+++ b/lib/hlsjs-p2p-wrapper.js
@@ -16,6 +16,24 @@ class HlsjsP2PWrapper {
                 return wrapper.peerAgentModule.stats;
             }
         });
+
+        Object.defineProperty(this, "p2pDownloadOn", {
+            get: () => {
+                return wrapper.peerAgentModule.p2pDownloadOn;
+            },
+            set: (on) => {
+                wrapper.peerAgentModule.p2pDownloadOn = on;
+            }
+        });
+
+        Object.defineProperty(this, "p2pUploadOn", {
+            get: () => {
+                return wrapper.peerAgentModule.p2pUploadOn;
+            },
+            set: (on) => {
+                wrapper.peerAgentModule.p2pUploadOn = on;
+            }
+        });
     }
 
     static get version() {


### PR DESCRIPTION
To make this feature usable for Hls.js customers, we have to expose it via the wrapper.

NOTE: to test this properly we should set up babel rewire with our unit tests so we can really mock the wrapper in API layer.