### PR TITLE
Hlsjs v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog's template come from [keepachangelog.com](http://keepachangelog.com/). When editing this document, please follow the convention specified there.
 
 ## [Dev]
+### Updated
+- hls.js to 0.6.1.
 
 ## [Unreleased]
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@
 const _VERSION_ = require('./package').version;
 
 function makeBrowserifyTask (src, dest, standalone, dev) {
+    'use strict';
     let task = {
         src: src,
         dest: dest,

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "dependencies": {
-    "hls.js": "0.5.46",
+    "hls.js": "0.6.1",
     "lodash.assigninwith": "^4.0.7",
     "lodash.defaults": "4.0.1",
     "streamroot-p2p": "^4.0.0",

--- a/test/hls-controllers.js
+++ b/test/hls-controllers.js
@@ -53,10 +53,15 @@ describe("Hls controllers", () => {
             length: 128000
         };
 
+        // monkey-patch up a working StreamController
         streamController.state = 'FRAG_LOADING';
         streamController.fragCurrent = frag;
         streamController.levels = hlsMock.levels;
         streamController.level = 0;
+        streamController.demuxer = {
+            push() {}
+        };
+
         streamController.onFragLoaded({frag, stats});
 
         streamController.stats.should.be.equal(stats);

--- a/test/hls-controllers.js
+++ b/test/hls-controllers.js
@@ -27,11 +27,11 @@ describe("Hls controllers", () => {
         };
 
         abrController.onFragLoading({frag});
+        abrController.onFragLoadProgress({frag, stats});
         abrController.onFragLoaded({frag, stats});
 
-        abrController.bwEstimator.getEstimate().should.be.approximately(1024000, 4000);
+        abrController.lastbw.should.be.approximately(1024000, 4000);
         abrController.lastLoadedFragLevel.should.be.equal(frag.level);
-
     });
 
     it("should estimate the right bandwidth according to stats of buffered fragment", () => {

--- a/test/html/bundle.js
+++ b/test/html/bundle.js
@@ -107,7 +107,7 @@ describe("StreamrootHlsjsBundle", function() { // NOTE: We need to use the oldsc
         hls.on(Hls.Events.MANIFEST_PARSED,function() {
             video.volume = 0;
             video.play();
-            cb();
+            cb && cb();
         });
     }
 

--- a/test/html/p2p-loader-generator.js
+++ b/test/html/p2p-loader-generator.js
@@ -95,7 +95,7 @@ describe("P2PLoaderGenerator", function() { // using plain ES5 function here
 
             console.log('Estimated BW: ' + estimatedBW);
 
-            (hls.abrController.bwEstimator.getEstimate() / estimatedBW).should.be.approximately(1, 0.01); // delta of 1%
+            (hls.abrController.lastbw / estimatedBW).should.be.approximately(1, 0.01); // delta of 1%
 
             done();
         }


### PR DESCRIPTION
Some internal changes needed fixes in our integration test setup. No functional changes required adaptation on Streamroot P2P tech side.

Acceptance tests results:

* all usage modes (wrapper, bundle, legacy) working 
(Firefox OK, Chrome: ARTE test stream broken ⚠️  - MediaSource related error, probably not on our side) NOTE: also tested the ARTE stream (http://www.streambox.fr/playlists/test_001/stream.m3u8) in official hls.js demo, and error says video is using unsupported native features (codec issue?) - 

* Hls.js bundled demo working (Firefox & Chrome)
