### PR TITLE
Update bundled hls.js version to 0.5.51

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Updated
+- Bundles hls.js 0.5.51
 
 ## [3.7.12] - 2016-11-03
 ### Updated

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This module wraps an instance of [`hls.js`](https://github.com/dailymotion/hls.js) to bootstrap it with [the Streamroot P2P module](http://streamroot.io).
 
 It provides a **bundle** that extends the [`hls.js`](https://github.com/dailymotion/hls.js) constructor to create a fully configured player which will use the Streamroot P2P module, giving you the exact same API.
-You can integrate this bundle with minimal changes in your application (you only need to add an additional argument to the [`hls.js`](https://github.com/dailymotion/hls.js) constructor). **The bundled version of [`hls.js`](https://github.com/dailymotion/hls.js) is [`v0.6.1`](https://github.com/dailymotion/hls.js/releases/tag/v0.6.1)**.
+You can integrate this bundle with minimal changes in your application (you only need to add an additional argument to the [`hls.js`](https://github.com/dailymotion/hls.js) constructor). **The bundled version of [`hls.js`](https://github.com/dailymotion/hls.js) is [`v0.5.51`](https://github.com/dailymotion/hls.js/releases/tag/v0.5.51)**.
 
 It also provides a **wrapper** that allows you to create/configure a player with a specific version of [`hls.js`](https://github.com/dailymotion/hls.js).  
 Supported versions of [`hls.js`](https://github.com/dailymotion/hls.js): from [`v0.5.46`](https://github.com/dailymotion/hls.js/releases/tag/v0.5.46) to [`v0.6.1`](https://github.com/dailymotion/hls.js/releases/tag/v0.6.1).

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "dependencies": {
-    "hls.js": "0.6.1",
+    "hls.js": "0.5.51",
     "lodash.assigninwith": "^4.0.7",
     "lodash.defaults": "4.0.1",
     "streamroot-p2p": "^4.0.0",

--- a/test/hls-controllers.js
+++ b/test/hls-controllers.js
@@ -22,15 +22,16 @@ describe("Hls controllers", () => {
         };
 
         const stats = {
+            tbuffered: Date.now(),
             trequest: Date.now() - 1000,
             loaded: 128000
         };
 
         abrController.onFragLoading({frag});
-        abrController.onFragLoadProgress({frag, stats});
         abrController.onFragLoaded({frag, stats});
+        abrController.onFragBuffered({frag, stats});
 
-        abrController.lastbw.should.be.approximately(1024000, 4000);
+        abrController.bwEstimator.getEstimate().should.be.approximately(1024000, 4000);
         abrController.lastLoadedFragLevel.should.be.equal(frag.level);
     });
 

--- a/test/html/p2p-loader-generator.js
+++ b/test/html/p2p-loader-generator.js
@@ -95,7 +95,7 @@ describe("P2PLoaderGenerator", function() { // using plain ES5 function here
 
             console.log('Estimated BW: ' + estimatedBW);
 
-            (hls.abrController.lastbw / estimatedBW).should.be.approximately(1, 0.01); // delta of 1%
+            (hls.abrController.bwEstimator.getEstimate() / estimatedBW).should.be.approximately(1, 0.05); // delta of 5%
 
             done();
         }


### PR DESCRIPTION
Karma tests are failing because there is no media source in `PhantomJS`, therefore the `FRAG_BUFFERED` event is not triggered. And the way this [test](https://github.com/streamroot/hlsjs-p2p-wrapper/blob/1ed5097fca3fe9ea55561276e4a23a07a1dce032/test/html/p2p-loader-generator.js#L44-L102) is done is not reliable enough.