### PR TITLE
Expect HttpError instance passed in loadError callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+- Expect HttpError instance passed in loadError callback
 
 ## [3.8.0] - 2016-11-07
 ### Fixed


### PR DESCRIPTION
Pushed change in master by mistake. Cancelled circle ci build before anything was built.
See last commit in master. 
Merging this change will trigger the correct CI build