### PR TITLE
4.6.x

### DIFF
--- a/lib/hlsjs-p2p-wrapper-private.js
+++ b/lib/hlsjs-p2p-wrapper-private.js
@@ -211,7 +211,7 @@ class HlsjsP2PWrapperPrivate {
         // attach error handling to media engine
         hlsjs.on(hlsEventsEnum.ERROR, this.onMediaEngineError);
 
-        const playerBridge = new PlayerInterface(hlsjs, hlsEventsEnum, p2pConfig, this.onDispose.bind(this));
+        const playerBridge = new PlayerInterface(hlsjs, hlsEventsEnum, this.onDispose.bind(this));
         const mediaMap = new MediaMap(hlsjs);
 
         this.peerAgentModule = new StreamrootPeerAgentModule(playerBridge, contentUrl, mediaMap, p2pConfig, SegmentView, streamType, integrationVersion);

--- a/lib/integration/player-interface.js
+++ b/lib/integration/player-interface.js
@@ -8,7 +8,6 @@ class PlayerInterface extends EventEmitter {
 
         this.hls = hls;
 
-        this.liveMinBufferMargin = p2pConfig.liveMinBufferMargin || 10;
 
         this.onDispose = onDispose;
 
@@ -47,10 +46,10 @@ class PlayerInterface extends EventEmitter {
         let maxBufferLevel;
         if (this.hls.config.liveSyncDuration) {
             confParam = "liveSyncDuration";
-            maxBufferLevel = this.hls.config.liveSyncDuration - this.liveMinBufferMargin;
+            maxBufferLevel = this.hls.config.liveSyncDuration;
         } else {
             confParam = "maxBufferLength";
-            maxBufferLevel = this.hls.config.maxBufferLength - this.liveMinBufferMargin;
+            maxBufferLevel = this.hls.config.maxBufferLength;
         }
 
         if (maxBufferLevel < 0) {
@@ -62,7 +61,7 @@ class PlayerInterface extends EventEmitter {
 
     setBufferMarginLive(bufferLevel) {
         this.hls.config.maxBufferSize = 0;
-        this.hls.config.maxBufferLength = bufferLevel + this.liveMinBufferMargin;
+        this.hls.config.maxBufferLength = bufferLevel;
     }
 
     addEventListener(eventName, listener) {

--- a/lib/integration/player-interface.js
+++ b/lib/integration/player-interface.js
@@ -3,7 +3,7 @@ import TrackView from './mapping/track-view';
 
 class PlayerInterface extends EventEmitter {
 
-    constructor(hls, Events, p2pConfig, onDispose) {
+    constructor(hls, Events, onDispose) {
         super();
 
         this.hls = hls;


### PR DESCRIPTION
Support for changes in v4.6 branch of peer-agent.

We could remove getBufferLevelMax entirely from player interface in this release or the next.