### PR TITLE
Exposing peer agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 
 ### Changed
 - Wrapper instantiation: Hlsjs class injection replaced by hls.js instance injection. Wrapper can be initialized at any time of hls.js lifecycle(even after hls.js started playback) now.
+- Accessing peer agent public API: wrapper instance getters/setters `stats`, `p2pDownloadOn`, `p2pUploadOn` were removed, peer agent public API getter was introduced instead. -- `wrapper.peerAgent`. The list of getters it exposes: `wrapper.peerAgent.version` -- peer agent version, `wrapper.peerAgent.stats`, `wrapper.peerAgent.isP2PEnabled`. Getters/setters: `wrapper.peerAgent.p2pDownloadOn`, `wrapper.peerAgent.p2pUploadOn`;
 
 ### Removed
 - Due to simplifed wrapper creation, its methods `createMediaEngine`, `createPlayer`, `createSRModule`, `createPeerAgent` were removed.

--- a/lib/hlsjs-p2p-wrapper.js
+++ b/lib/hlsjs-p2p-wrapper.js
@@ -2,12 +2,14 @@
 
 import HlsjsP2PWrapperPrivate from './hlsjs-p2p-wrapper-private';
 import StreamrootPeerAgentModule from 'streamroot-p2p';
+import PeerAgentAPI from './peer-agent-api';
 
 class HlsjsP2PWrapper {
 
     constructor(p2pConfig, hlsjs) {
         let wrapper = new HlsjsP2PWrapperPrivate(p2pConfig, hlsjs, StreamrootPeerAgentModule);
 
+        this.peerAgent = PeerAgentAPI.get(wrapper);
     }
 
     get version() {

--- a/lib/hlsjs-p2p-wrapper.js
+++ b/lib/hlsjs-p2p-wrapper.js
@@ -8,29 +8,6 @@ class HlsjsP2PWrapper {
     constructor(p2pConfig, hlsjs) {
         let wrapper = new HlsjsP2PWrapperPrivate(p2pConfig, hlsjs, StreamrootPeerAgentModule);
 
-        Object.defineProperty(this, "stats", {
-            get() {
-                return wrapper.peerAgentModule.stats;
-            }
-        });
-
-        Object.defineProperty(this, "p2pDownloadOn", {
-            get: () => {
-                return wrapper.peerAgentModule.p2pDownloadOn;
-            },
-            set: (on) => {
-                wrapper.peerAgentModule.p2pDownloadOn = on;
-            }
-        });
-
-        Object.defineProperty(this, "p2pUploadOn", {
-            get: () => {
-                return wrapper.peerAgentModule.p2pUploadOn;
-            },
-            set: (on) => {
-                wrapper.peerAgentModule.p2pUploadOn = on;
-            }
-        });
     }
 
     get version() {

--- a/lib/peer-agent-api.js
+++ b/lib/peer-agent-api.js
@@ -1,0 +1,35 @@
+function getPeerAgentAPI(privateWrapper) {
+
+    const peerAgentAPI = {
+
+        get stats() {
+            return privateWrapper.peerAgentModule.stats;
+        },
+
+        get version() {
+            return privateWrapper.peerAgentModule.version;
+        },
+
+        get isP2PEnabled() {
+            return privateWrapper.peerAgentModule.isP2PEnabled;
+        },
+
+        get p2pDownloadOn() {
+            return privateWrapper.peerAgentModule.p2pDownloadOn;
+        },
+        set p2pDownloadOn(value) {
+            privateWrapper.peerAgentModule.p2pDownloadOn = value;
+        },
+
+        get p2pUploadOn() {
+            return privateWrapper.peerAgentModule.p2pUploadOn;
+        },
+        set p2pUploadOn(value) {
+            privateWrapper.peerAgentModule.p2pUploadOn = value;
+        },
+    };
+
+    return peerAgentAPI;
+}
+
+export default { get: getPeerAgentAPI };

--- a/test/peer-agent-api.js
+++ b/test/peer-agent-api.js
@@ -1,0 +1,66 @@
+import PeerAgentAPI from '../lib/peer-agent-api';
+
+const peerAgentMock = {
+    isP2PEnabled: true,
+    p2pDownloadOn: true,
+    stats: {},
+    version: 'fakeVersion',
+    p2pUploadOn: true,
+    dispose: () => {
+
+    }
+};
+
+const privateWrapperMock = {
+    peerAgentModule: peerAgentMock,
+};
+
+describe('PeerAgentAPI', () => {
+    it('should expose defined list of properties only', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.should.eql({
+            stats: peerAgentMock.stats,
+            version: peerAgentMock.version,
+            isP2PEnabled: peerAgentMock.isP2PEnabled,
+            p2pDownloadOn: peerAgentMock.p2pDownloadOn,
+            p2pUploadOn: peerAgentMock.p2pUploadOn,
+        });
+    });
+
+    it('should expose stats correctly and throw if trying to set its value', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.stats.should.equal(peerAgentMock.stats);
+        (() => { peerAgentAPI.stats = {}; }).should.throw();
+    });
+
+    it('should expose correct peer agent version', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.version.should.equal(peerAgentMock.version);
+    });
+
+    it('should expose isP2PEnabled correctly and throw if trying to set its value', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.isP2PEnabled.should.equal(peerAgentMock.isP2PEnabled);
+        (() => { peerAgentAPI.isP2PEnabled = false; }).should.throw();
+    });
+
+    it('should expose p2pDownloadOn correctly and allow setting its value', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.p2pDownloadOn.should.equal(peerAgentMock.p2pDownloadOn);
+        peerAgentAPI.p2pDownloadOn = false;
+        peerAgentAPI.p2pDownloadOn.should.equal(false);
+    });
+
+    it('should expose p2pUploadOn correctly and allow setting its value', () => {
+        const peerAgentAPI = PeerAgentAPI.get(privateWrapperMock);
+
+        peerAgentAPI.p2pUploadOn.should.equal(peerAgentMock.p2pUploadOn);
+        peerAgentAPI.p2pUploadOn = false;
+        peerAgentAPI.p2pUploadOn.should.equal(false);
+    });
+});


### PR DESCRIPTION
PR story https://www.pivotaltracker.com/story/show/134849477

Removed peer agent related getters/setters from wrapper instance.
Created peer agent public API object, that is exposed on wrapper instance through getter `wrapper.peerAgent`.