### PR TITLE
Bumping bundled hlsjs version to v0.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 
 ## [Dev]
 ### Changed
-- Bundled hls.js version from v0.5.46 to v0.6.12.
+- Changed bundled hls.js version from v0.5.46 to v0.6.12.
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This changelog's template come from [keepachangelog.com](http://keepachangelog.com/). When editing this document, please follow the convention specified there.
 
 ## [Dev]
+### Changed
+- Bundled hls.js version from v0.5.46 to v0.6.12.
 
 ## [Unreleased]
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This module wraps an instance of [`hls.js`](https://github.com/dailymotion/hls.js) to bootstrap it with [the Streamroot P2P module](http://streamroot.io).
 
 It provides a **bundle** that extends the [`hls.js`](https://github.com/dailymotion/hls.js) constructor to create a fully configured player which will use the Streamroot P2P module, giving you the exact same API.
-You can integrate this bundle with minimal changes in your application (you only need to add an additional argument to the [`hls.js`](https://github.com/dailymotion/hls.js) constructor). **The bundled version of [`hls.js`](https://github.com/dailymotion/hls.js) is [`v0.5.46`](https://github.com/dailymotion/hls.js/releases/tag/v0.5.46)**.
+You can integrate this bundle with minimal changes in your application (you only need to add an additional argument to the [`hls.js`](https://github.com/dailymotion/hls.js) constructor). **The bundled version of [`hls.js`](https://github.com/dailymotion/hls.js) is [`v0.6.12`](https://github.com/dailymotion/hls.js/releases/tag/v0.6.12)**.
 
 It also provides a **wrapper** that allows you to create/configure a player with a specific version of [`hls.js`](https://github.com/dailymotion/hls.js).
 Supported versions of [`hls.js`](https://github.com/dailymotion/hls.js): from [`v0.5.46`](https://github.com/dailymotion/hls.js/releases/tag/v0.5.46) to [`v0.6.12`](https://github.com/dailymotion/hls.js/releases/tag/v0.6.12).

--- a/lib/integration/p2p-loader-generator-v0-5-46.js
+++ b/lib/integration/p2p-loader-generator-v0-5-46.js
@@ -81,6 +81,7 @@ const P2PLoaderGenerator_v0_5_46 = function (hlsjsWrapper) {
             };
 
             this.stats.tload = performance.now();
+            this.stats.loaded = segmentData.byteLength;
             this.onSuccess(event, this.stats);
             this.reset();
         }

--- a/lib/integration/p2p-loader-generator-v0-6-2.js
+++ b/lib/integration/p2p-loader-generator-v0-6-2.js
@@ -72,6 +72,7 @@ const P2PLoaderGenerator_v0_6_2 = function (hlsjsWrapper) {
             };
 
             this.stats.tload = performance.now();
+            this.stats.loaded = segmentData.byteLength;
             this.stats.total = this.stats.loaded;
             this.callbacks.onSuccess(response, this.stats, this.context);
             this.reset();

--- a/lib/integration/p2p-loader-generator-v0-6-2.js
+++ b/lib/integration/p2p-loader-generator-v0-6-2.js
@@ -72,6 +72,7 @@ const P2PLoaderGenerator_v0_6_2 = function (hlsjsWrapper) {
             };
 
             this.stats.tload = performance.now();
+            this.stats.total = this.stats.loaded;
             this.callbacks.onSuccess(response, this.stats, this.context);
             this.reset();
         }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     ]
   },
   "dependencies": {
-    "hls.js": "0.5.46",
+    "hls.js": "0.6.12",
     "lodash.assigninwith": "^4.0.7",
     "lodash.defaults": "4.0.1",
     "streamroot-p2p": "^4.0.0",

--- a/test/hls-controllers.js
+++ b/test/hls-controllers.js
@@ -81,7 +81,7 @@ describe("Hls controllers", () => {
         streamController.doTick = function() {};
         streamController.onBufferAppended({parent: 'main'});
 
-        streamController.fragLastKbps.should.be.approximately(1024, 8);
+        streamController.fragLastKbps.should.be.approximately(1000, 24);
 
     });
 

--- a/test/hls-controllers.js
+++ b/test/hls-controllers.js
@@ -21,8 +21,9 @@ describe("Hls controllers", () => {
             level: 1
         };
 
+        let now = Date.now();
         const stats = {
-            trequest: Date.now() - 1000,
+            trequest: now - 1000,
             loaded: 128000
         };
 
@@ -45,9 +46,10 @@ describe("Hls controllers", () => {
             sn: 0
         };
 
+        let now = Date.now();
         const stats = {
-            trequest: Date.now() - 1000,
-            tfirst: Date.now() - 1000,
+            trequest: now - 1000,
+            tfirst: now - 1000,
             loaded: 128000,
             length: 128000
         };

--- a/test/hls-controllers.js
+++ b/test/hls-controllers.js
@@ -18,12 +18,15 @@ describe("Hls controllers", () => {
         const frag = {
             loadCounter: 1,
             url: "http://foo.bar/foo",
-            level: 1
+            level: 1,
+            bitrateTest: true,
+            type: "main"
         };
 
         let now = Date.now();
         const stats = {
             trequest: now - 1000,
+            tload: now,
             loaded: 128000
         };
 
@@ -43,7 +46,8 @@ describe("Hls controllers", () => {
             loadCounter: 1,
             url: "http://foo.bar/foo",
             level: 1,
-            sn: 0
+            sn: 0,
+            type: "main"
         };
 
         let now = Date.now();
@@ -51,7 +55,7 @@ describe("Hls controllers", () => {
             trequest: now - 1000,
             tfirst: now - 1000,
             loaded: 128000,
-            length: 128000
+            total: 128000
         };
 
         // monkey-patch up a working StreamController
@@ -75,7 +79,7 @@ describe("Hls controllers", () => {
         };
 
         streamController.doTick = function() {};
-        streamController.onBufferAppended();
+        streamController.onBufferAppended({parent: 'main'});
 
         streamController.fragLastKbps.should.be.approximately(1024, 8);
 

--- a/test/html/p2p-loader-generator.js
+++ b/test/html/p2p-loader-generator.js
@@ -54,7 +54,9 @@ describe("P2PLoaderGenerator", function() { // using plain ES5 function here
         const frag = {
             loadCounter: 1,
             url: TEST_URL1,
-            level: 0
+            level: 0,
+            bitrateTest: true,
+            type: "main",
         };
 
         hls.levelController._levels = hlsjsMock.levels;
@@ -118,7 +120,8 @@ describe("P2PLoaderGenerator", function() { // using plain ES5 function here
 
         let frag = {
             url: TEST_URL1 + "foo",
-            level: 0
+            level: 0,
+            type: "main",
         };
 
         hls.levelController._levels = hlsjsMock.levels;


### PR DESCRIPTION
PT story https://www.pivotaltracker.com/story/show/135688599

1. Fixed tests.
1. Fixed missing `total` field in `stats` object, passed to `onSuccessCallback`.
