### PR TITLE
Quick fix for a bug where update_demo.rb script fails when build path have spaces.

### DIFF
--- a/update_demo.rb
+++ b/update_demo.rb
@@ -15,7 +15,7 @@ DEMO_DIR = File.join(CURRENT_FOLDER, "demo-hls.js")
 
 Dir.chdir(CURRENT_FOLDER)
 
-`mkdir -p #{DEMO_DIR}`
+`mkdir -p "#{DEMO_DIR}"`
 
 Dir.chdir(DEMO_DIR)
 


### PR DESCRIPTION
The path in the generated mkdir is not put in a double quote, thus when
there is a space in the path it would be split into 2 different mkdirs.