### PR TITLE
Update hls.js dependency to 0.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ### Added
 - Optional `bitrate` field as been added to **TrackView**.
 
+### Updated
+- Wrapper now supports hls.js up to version `0.6.21`.
+- Bundles hls.js `0.6.21`.
+
 ## [Unreleased]
 
 ## [4.2.3] - 2017-01-30

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "hls.js": "0.6.12",
+    "hls.js": "0.6.20",
     "lodash.assigninwith": "^4.0.7",
     "lodash.defaults": "4.0.1",
     "streamroot-p2p": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "hls.js": "0.6.20",
+    "hls.js": "0.6.21",
     "lodash.assigninwith": "^4.0.7",
     "lodash.defaults": "4.0.1",
     "streamroot-p2p": "^4.0.0",

--- a/test/hls-controllers.js
+++ b/test/hls-controllers.js
@@ -42,6 +42,9 @@ describe("Hls controllers", () => {
         let hlsMock = new HlsMock(5, false, 0, false);
         let streamController = new StreamController(hlsMock);
 
+        // Invoke this to initialize bufferRange, which helps bypass a bufferRange check inside onBufferAppended added in 0.6.21
+        streamController.onManifestLoading();
+
         const frag = {
             loadCounter: 1,
             url: "http://foo.bar/foo",

--- a/update_demo.rb
+++ b/update_demo.rb
@@ -8,7 +8,7 @@ CURRENT_FOLDER = File.expand_path(File.dirname(__FILE__))
 
 PACKAGE = File.read(File.join(CURRENT_FOLDER, 'package.json'))
 PACKAGE_HASH = JSON.parse(PACKAGE)
-VERSION = PACKAGE_HASH['dependencies']['hls.js']
+VERSION = PACKAGE_HASH['dependencies']['hls.js'].sub('^', '');
 
 FILENAME = "v#{VERSION}.tar.gz"
 DEMO_DIR = File.join(CURRENT_FOLDER, "demo-hls.js")


### PR DESCRIPTION
Aside from a broken test case related to [this line in hls.js](https://github.com/dailymotion/hls.js/blob/5df6560e48c0d21e1bcdd3df277ca1f0fa415efe/src/controller/stream-controller.js#L1189) I have not found any major incompatibility on the new version.