### PR TITLE
Does not instantiate wrapper if passed a null or undefined HLS.js instance.

### DIFF
--- a/lib/hlsjs-p2p-wrapper.js
+++ b/lib/hlsjs-p2p-wrapper.js
@@ -7,14 +7,16 @@ import PeerAgentAPI from './peer-agent-api';
 class HlsjsP2PWrapper {
 
     constructor(p2pConfig, hlsjs) {
-        let wrapper = new HlsjsP2PWrapperPrivate(p2pConfig, hlsjs, StreamrootPeerAgentModule);
+        if (!!hlsjs) {
+            let wrapper = new HlsjsP2PWrapperPrivate(p2pConfig, hlsjs, StreamrootPeerAgentModule);
 
-        let peerAgentAPI = PeerAgentAPI.get(wrapper);
-        Object.defineProperty(this, 'peerAgent', {
-            get() {
-                return wrapper.peerAgentModule ? peerAgentAPI : null;
-            }
-        });
+            let peerAgentAPI = PeerAgentAPI.get(wrapper);
+            Object.defineProperty(this, 'peerAgent', {
+                get() {
+                    return wrapper.peerAgentModule ? peerAgentAPI : null;
+                }
+            });
+        }
     }
 
     get version() {

--- a/lib/hlsjs-p2p-wrapper.js
+++ b/lib/hlsjs-p2p-wrapper.js
@@ -16,6 +16,8 @@ class HlsjsP2PWrapper {
                     return wrapper.peerAgentModule ? peerAgentAPI : null;
                 }
             });
+        } else {
+            console.error('HLS.js instance must not be \'null\' or \'undefined\'.');
         }
     }
 

--- a/lib/hlsjs-p2p-wrapper.js
+++ b/lib/hlsjs-p2p-wrapper.js
@@ -7,7 +7,7 @@ import PeerAgentAPI from './peer-agent-api';
 class HlsjsP2PWrapper {
 
     constructor(p2pConfig, hlsjs) {
-        if (!!hlsjs) {
+        if (hlsjs) {
             let wrapper = new HlsjsP2PWrapperPrivate(p2pConfig, hlsjs, StreamrootPeerAgentModule);
 
             let peerAgentAPI = PeerAgentAPI.get(wrapper);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "streamroot-hlsjs-p2p-wrapper",
-  "version": "4.3.0-beta.0",
+  "version": "4.4.0-beta.0",
   "main": "./lib/hlsjs-p2p-wrapper-private.js",
   "homepage": "www.streamroot.io",
   "author": {


### PR DESCRIPTION
Currently there is no `null` or `undefined` checking for wrapper instantiation which could happen if a player fall back on Flash as in https://www.pivotaltracker.com/n/projects/1597593. This add the behavior to stop the instantiation of the wrapper when this happens.