### PR TITLE
Emergency track switch count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 
 ## [Unreleased]
 ### Added
-- Notifying peer-agent about emergency frag load abort(track switch due to bandwidht drop).
+- Notifying peer-agent about emergency frag load abort(track switch due to bandwidth drop).
 
 ## [4.3.3] - 2017-02-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Added
+- Notifying peer-agent about emergency frag load abort(track switch due to bandwidht drop).
 
 ## [4.3.3] - 2017-02-27
 ### Added

--- a/example/bundle/index.html
+++ b/example/bundle/index.html
@@ -1,17 +1,10 @@
 <html>
     <head>
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.js"> </script>
-        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.css">
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.4.9/d3.min.js"> </script>
-
         <script src="../config.js"></script>
 
         <script>
             window.previousTotalCDN = 0;
         </script>
-
-        <script src="http://cdn.streamroot.io/2/scripts/p2pGraph.js"></script>
-        <script src="http://cdn.streamroot.io/2/scripts/peerStat.js"></script>
 
         <script src="../../dist/bundle/hlsjs-p2p-bundle.js"></script>
 
@@ -58,5 +51,8 @@
     <body>
         <div id="error"></div>
         <video controls id="video"></video>
+
+        <div id="streamroot-graphs"></div>
+        <script src="https://tools.streamroot.io/usage-graphs/latest/graphs.js"></script>
     </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -1,8 +1,6 @@
 <html>
 
 <head>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.js"> </script>
-    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.css">
 </head>
 
 <body style="width:500px;margin-left:3em;margin-top:3em">

--- a/example/wrapper/index.html
+++ b/example/wrapper/index.html
@@ -1,16 +1,9 @@
 <html>
     <head>
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.js"> </script>
-        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/rickshaw/1.4.6/rickshaw.min.css">
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.4.9/d3.min.js"> </script>
-
         <script src="../config.js"></script>
 
         <script src="../../node_modules/hls.js/dist/hls.js"></script>
         <script src="../../dist/wrapper/hlsjs-p2p-wrapper.js"></script>
-
-        <script src="http://cdn.streamroot.io/2/scripts/p2pGraph.js"></script>
-        <script src="http://cdn.streamroot.io/2/scripts/peerStat.js"></script>
 
         <script>
 
@@ -55,5 +48,8 @@
     <body>
         <div id="error"></div>
         <video controls id="video"></video>
+
+        <div id="streamroot-graphs"></div>
+        <script src="https://tools.streamroot.io/usage-graphs/latest/graphs.js"></script>
     </body>
 </html>

--- a/lib/integration/external-events.js
+++ b/lib/integration/external-events.js
@@ -1,0 +1,15 @@
+const TRACK_CHANGE_EVENT = 'onTrackChange';
+
+const supportedEvents = [
+    TRACK_CHANGE_EVENT,
+];
+
+const isSupported = (eventName) => supportedEvents.indexOf(eventName) > -1;
+
+module.exports = {
+
+    TRACK_CHANGE_EVENT,
+
+    isSupported
+
+};

--- a/lib/integration/external-events.js
+++ b/lib/integration/external-events.js
@@ -1,7 +1,9 @@
 const TRACK_CHANGE_EVENT = 'onTrackChange';
+const EMERGENCY_FRAG_LOAD_ABORT = 'onEmergencyFragLoadAborted';
 
 const supportedEvents = [
     TRACK_CHANGE_EVENT,
+    EMERGENCY_FRAG_LOAD_ABORT
 ];
 
 const isSupported = (eventName) => supportedEvents.indexOf(eventName) > -1;
@@ -9,6 +11,7 @@ const isSupported = (eventName) => supportedEvents.indexOf(eventName) > -1;
 module.exports = {
 
     TRACK_CHANGE_EVENT,
+    EMERGENCY_FRAG_LOAD_ABORT,
 
     isSupported
 

--- a/lib/integration/player-interface.js
+++ b/lib/integration/player-interface.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 import TrackView from './mapping/track-view';
+import ExternalEvents from './external-events';
 
 class PlayerInterface extends EventEmitter {
 
@@ -14,7 +15,7 @@ class PlayerInterface extends EventEmitter {
         // eslint-disable-next-line no-unused-vars
         this.hls.on(hls.constructor.Events.LEVEL_SWITCH, (event, data) => {
             const { urlId, bitrate } = this.hls.levels[data.level];
-            this.emit('onTrackChange', {
+            this.emit(ExternalEvents.TRACK_CHANGE_EVENT, {
                 video: new TrackView({ urlId, bitrate, level: data.level })
             });
         });
@@ -66,18 +67,18 @@ class PlayerInterface extends EventEmitter {
     }
 
     addEventListener(eventName, listener) {
-        if (eventName === 'onTrackChange') {
+        if (ExternalEvents.isSupported(eventName)) {
             this.on(eventName, listener);
         } else {
-      // throw new Error('Tried to addEventListener for other event than onTrackChange. Check streamroot-p2p version');
+      // throw new Error('Tried to addEventListener for an unsupported event. Check streamroot-p2p version');
         }
     }
 
     removeEventListener(eventName, listener) {
-        if (eventName === 'onTrackChange') {
+        if (ExternalEvents.isSupported(eventName)) {
             this.removeListener(eventName, listener);
         } else {
-      // throw new Error('Tried to removeEventListener for other event than onTrackChange. Check streamroot-p2p version');
+      // throw new Error('Tried to removeEventListener for an unsupported event. Check streamroot-p2p version');
         }
     }
 

--- a/lib/integration/player-interface.js
+++ b/lib/integration/player-interface.js
@@ -74,7 +74,7 @@ class PlayerInterface extends EventEmitter {
         if (ExternalEvents.isSupported(eventName)) {
             this.on(eventName, listener);
         } else {
-      // throw new Error('Tried to addEventListener for an unsupported event. Check streamroot-p2p version');
+            console.warn('Trying to add an unsupported event listener. eventName=', eventName);
         }
     }
 
@@ -82,7 +82,7 @@ class PlayerInterface extends EventEmitter {
         if (ExternalEvents.isSupported(eventName)) {
             this.removeListener(eventName, listener);
         } else {
-      // throw new Error('Tried to removeEventListener for an unsupported event. Check streamroot-p2p version');
+            console.warn('Trying to remove an unsupported event listener. eventName=', eventName);
         }
     }
 

--- a/lib/integration/player-interface.js
+++ b/lib/integration/player-interface.js
@@ -36,7 +36,7 @@ class PlayerInterface extends EventEmitter {
 
         const DESTROYING_EVENT = hls.constructor.Events.DESTROYING;
         if (DESTROYING_EVENT === undefined) {
-            throw new Error('Can not find DESTROYING_EVENT hls.js event.');
+            throw new Error('Can not find DESTROYING event hls.js event.');
         }
         this.hls.on(DESTROYING_EVENT, () => {
             this.onDispose();

--- a/lib/integration/player-interface.js
+++ b/lib/integration/player-interface.js
@@ -12,19 +12,33 @@ class PlayerInterface extends EventEmitter {
 
         this.onDispose = onDispose;
 
+        // LEVEL_SWITCH is going to be deprecated in next major release
+        // https://github.com/dailymotion/hls.js/blob/2287cfebc187db0d342aca03773410abc8872f6c/src/events.js#L32
+        const QUALITY_CHANGE_EVENT = hls.constructor.Events.LEVEL_SWITCH || hls.constructor.Events.LEVEL_SWITCHING;
+        if (QUALITY_CHANGE_EVENT === undefined) {
+            throw new Error('Can\'t find neither LEVEL_SWITCH nor LEVEL_SWITCHING hls.js event.');
+        }
         // eslint-disable-next-line no-unused-vars
-        this.hls.on(hls.constructor.Events.LEVEL_SWITCH, (event, data) => {
+        this.hls.on(QUALITY_CHANGE_EVENT, (event, data) => {
             const { urlId, bitrate } = this.hls.levels[data.level];
             this.emit(ExternalEvents.TRACK_CHANGE_EVENT, {
                 video: new TrackView({ urlId, bitrate, level: data.level })
             });
         });
 
-        this.hls.on(hls.constructor.Events.FRAG_LOAD_EMERGENCY_ABORTED, () => {
+        const FRAG_LOAD_EMERGENCY_ABORTED_EVENT = hls.constructor.Events.FRAG_LOAD_EMERGENCY_ABORTED;
+        if (FRAG_LOAD_EMERGENCY_ABORTED_EVENT === undefined) {
+            throw new Error('Can not find FRAG_LOAD_EMERGENCY_ABORTED hls.js event.');
+        }
+        this.hls.on(FRAG_LOAD_EMERGENCY_ABORTED_EVENT, () => {
             this.emit(ExternalEvents.EMERGENCY_FRAG_LOAD_ABORT);
         });
 
-        this.hls.on(hls.constructor.Events.DESTROYING, () => {
+        const DESTROYING_EVENT = hls.constructor.Events.DESTROYING;
+        if (DESTROYING_EVENT === undefined) {
+            throw new Error('Can not find DESTROYING_EVENT hls.js event.');
+        }
+        this.hls.on(DESTROYING_EVENT, () => {
             this.onDispose();
         });
     }

--- a/lib/integration/player-interface.js
+++ b/lib/integration/player-interface.js
@@ -20,6 +20,10 @@ class PlayerInterface extends EventEmitter {
             });
         });
 
+        this.hls.on(hls.constructor.Events.FRAG_LOAD_EMERGENCY_ABORTED, () => {
+            this.emit(ExternalEvents.EMERGENCY_FRAG_LOAD_ABORT);
+        });
+
         this.hls.on(hls.constructor.Events.DESTROYING, () => {
             this.onDispose();
         });

--- a/test/mocks/hls.js
+++ b/test/mocks/hls.js
@@ -53,7 +53,12 @@ class HlsMock {
     }
 
     static get Events() {
-        return {};
+        return {
+            LEVEL_SWITCH: 'LEVEL_SWITCH',
+            LEVEL_SWITCHING: 'LEVEL_SWITCHING',
+            FRAG_LOAD_EMERGENCY_ABORTED: 'FRAG_LOAD_EMERGENCY_ABORTED',
+            DESTROYING: 'DESTROYING',
+        };
     }
 
     on() {}


### PR DESCRIPTION
`hlsjs-p2p-wrapper`'s part of https://www.pivotaltracker.com/n/projects/1597593/stories/139005271

**What was done:**
1. Replaced old graphs.
1. Extracted external events to separate class.
1. Putting a warning in console if wrapper user tries to listen for an unsupported event.
1. Checking and throwing error if `hls.js` doesn't have expected events -- this means either no `hls.js` or, more likely, unsupported version of it is used.
1. Sending frag load abandonment event to `peer-agent`.