### PR TITLE
Enable mobile browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- Remove strict condition that avoided every mobile browser to be considered as not supported.
 
 ## [4.3.6] - 2017-03-17
 ### Added

--- a/lib/hlsjs-p2p-bundle.js
+++ b/lib/hlsjs-p2p-bundle.js
@@ -64,14 +64,7 @@ inheritStaticPropertiesReadOnly(StreamrootHlsjsBundle, Hlsjs);
 StreamrootHlsjsBundle.isSupported = function() {
     var isSafari = uaParserResult.browser.name === "Safari";
 
-    // Exclude mobile devices (careful: device properties aren't always defined, as in chrome for example, check mobile OS too).
-    var isMobile = uaParserResult.device.type === "mobile" ||
-                   uaParserResult.device.type === "tablet" ||
-                   uaParserResult.device.type === "console" ||
-                   uaParserResult.os.name === "Android" ||
-                   uaParserResult.os.name === "iOS";
-
-    return Hlsjs.isSupported() && !isSafari && !isMobile;
+    return Hlsjs.isSupported() && !isSafari;
 };
 
 /**


### PR DESCRIPTION
Removing this condition allows mobile browsers to work with our technology when the flag `mobileBrowsersEnabled` is enabled.

All repositories depending on `hlsjs-p2p-bundle` to work couldn't work properly on mobile because the integration was reporting it as unsupported.