### PR TITLE
Fix choice of loader version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- Fix choice of loader version
 
 ## [4.3.40] - 2017-08-11
 ### Added

--- a/lib/integration/p2p-loader-generator.js
+++ b/lib/integration/p2p-loader-generator.js
@@ -10,7 +10,7 @@ const P2PLoaderGenerator = function (hlsjsWrapper) {
         let versionParts = hlsjsVersion.split('.');
         let minor = versionParts[1];
         let patch = versionParts[2];
-        if (Number(minor) >= 6 && Number(patch) >= 2) {
+        if (Number(minor) >= 7 || (Number(minor) === 6 && Number(patch) >= 2)) {
             return p2pLoaderGenerator_v0_6_2(hlsjsWrapper);
         }
 


### PR DESCRIPTION
We load the newer loader version if hls.js version is >= 6.2. There was a mistake in the condition so we always enforced that the patch version was >= 2, which is not what we want