### PR TITLE
Support for url rewriting using xhrSetup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Added
+- Support url rewriting through `xhr.open` calls in `xhrSetup`
+
+### Changed
 - Update hls.js version to 0.8.2 in bundle
 - Bump integration version
 

--- a/lib/integration/p2p-loader-generator-v0-6-2.js
+++ b/lib/integration/p2p-loader-generator-v0-6-2.js
@@ -125,9 +125,8 @@ const P2PLoaderGenerator_v0_6_2 = function (hlsjsWrapper) {
                 throw new Error('P2P loader was not reset correctly, internal state indicates unfinalized request');
             }
 
-            let url = this.context.url;
             let xhrSetup = this.xhrSetup;
-            let {headers, withCredentials} = extractInfoFromXhrSetup(xhrSetup, url);
+            let {headers, withCredentials, url} = extractInfoFromXhrSetup(xhrSetup, this.context.url);
 
             if (!isNaN(this.context.rangeStart) && !isNaN(this.context.rangeEnd)) {
                 headers.Range = `bytes=${this.context.rangeStart}-${this.context.rangeEnd - 1}`;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,14 +24,24 @@ function inheritStaticPropertiesReadOnly(target, source) {
  * @returns a hash like {headers: Object, withCredentials: Boolean}. Headers object will at least be empty in any case
  *
  */
-function extractInfoFromXhrSetup(xhrSetup, url, headersBase) {
-    var headers = headersBase || {};
+function extractInfoFromXhrSetup(xhrSetup, originalURL, headersBase) {
+    const headers = headersBase || {};
+    let url = originalURL;
 
     const xhrMock = new BaseXHR({
         setRequestHeader: (header, value) => {
             headers[header] = value;
         },
-        withCredentials: false
+        withCredentials: false,
+        open: (method, openURL, async = true) => {
+            if (method !== 'GET') {
+                throw new Error('xhrSetup is calling open with a method other than GET, which is not supported at the moment. Please contact Streamroot support');
+            }
+            if (async !== true) {
+                throw new Error('xhrSetup is trying to open a synchronous request, which is not supported at the moment. Please contact Streamroot support');
+            }
+            url = openURL;
+        }
     });
 
     // In case xhrSetup calls functions others than the one implemented
@@ -39,12 +49,12 @@ function extractInfoFromXhrSetup(xhrSetup, url, headersBase) {
     // We will also throw explicitly at an attempt to set event handlers (on...)
     // A call to an undefined function will throw anyway
     try {
-        xhrSetup && xhrSetup(xhrMock, url);
+        xhrSetup && xhrSetup(xhrMock, originalURL);
     } catch (e) {
         throw new Error('xhrSetup is trying to acces a forbidden property/method of XHR mock. Please contact Streamroot support. Internal mock error: ' + e.message);
     }
 
-    return {headers, withCredentials: xhrMock.withCredentials};
+    return {headers, withCredentials: xhrMock.withCredentials, url};
 }
 
 export {

--- a/test/xhr-setup.js
+++ b/test/xhr-setup.js
@@ -35,13 +35,13 @@ describe("xhrSetup extractor",() => {
 
     it('should throw when we call open with a method other than GET', () => {
         extractInfoFromXhrSetup.bind(null, (xhr) => {
-            xhr.open('POST', 'foo', true)
+            xhr.open('POST', 'foo', true);
         }).should.throw;
     });
 
     it('should throw when we call open with sync=false', () => {
         extractInfoFromXhrSetup.bind(null, (xhr) => {
-            xhr.open('GET', 'foo', false)
+            xhr.open('GET', 'foo', false);
         }).should.throw;
     });
 
@@ -74,14 +74,14 @@ describe("xhrSetup extractor",() => {
 
     it('should return original URL when open is not called', () => {
         let originalURL = 'foobar';
-        let { url } = extractInfoFromXhrSetup((xhr, xhrSetupURL) => {}, originalURL);
+        let { url } = extractInfoFromXhrSetup((xhr, xhrSetupURL) => {}, originalURL); // eslint-disable-line no-unused-vars
         url.should.equal(originalURL);
     });
 
     it('should return URL passed to "open" when called', () => {
         let modifiedURL = "baz";
         let originalURL = 'foobar';
-        let { url } = extractInfoFromXhrSetup((xhr, xhrSetupURL) => {
+        let { url } = extractInfoFromXhrSetup((xhr, xhrSetupURL) => { // eslint-disable-line no-unused-vars
             xhr.open('GET', modifiedURL);
         }, originalURL);
         url.should.equal(modifiedURL);

--- a/test/xhr-setup.js
+++ b/test/xhr-setup.js
@@ -21,11 +21,9 @@ describe("xhrSetup extractor",() => {
     });
 
     it('should not throw when we call setRequestHeader', () => {
-
         extractInfoFromXhrSetup.bind(null, (xhr) => {
             xhr.setRequestHeader('SomeHeader', 'SomeValue');
         }).should.not.throw;
-
     });
 
     it('should not throw when we access withCredentials', () => {
@@ -33,6 +31,18 @@ describe("xhrSetup extractor",() => {
             xhr.withCredentials.should.be.false;
             xhr.withCredentials = true;
         }).should.not.throw;
+    });
+
+    it('should throw when we call open with a method other than GET', () => {
+        extractInfoFromXhrSetup.bind(null, (xhr) => {
+            xhr.open('POST', 'foo', true)
+        }).should.throw;
+    });
+
+    it('should throw when we call open with sync=false', () => {
+        extractInfoFromXhrSetup.bind(null, (xhr) => {
+            xhr.open('GET', 'foo', false)
+        }).should.throw;
     });
 
     it('should return a hash with correct values', () => {
@@ -46,13 +56,6 @@ describe("xhrSetup extractor",() => {
         withCredentials.should.be.true;
     });
 
-    it('should pass through URL to `xhrSetup` when present', () => {
-        extractInfoFromXhrSetup((xhr, url) => {
-            xhr.setRequestHeader('bla', 'bla');
-            url.should.eql('foobar');
-        }, "foobar");
-    });
-
     it('should extend base headers when present', () => {
         let {headers} = extractInfoFromXhrSetup((xhr, url) => {
             xhr.setRequestHeader('bla', 'bla');
@@ -62,4 +65,25 @@ describe("xhrSetup extractor",() => {
         headers.should.eql({foo: "bar", bla: 'bla'});
     });
 
+    it('should pass through URL to `xhrSetup` when present', () => {
+        extractInfoFromXhrSetup((xhr, url) => {
+            xhr.setRequestHeader('bla', 'bla');
+            url.should.eql('foobar');
+        }, "foobar");
+    });
+
+    it('should return original URL when open is not called', () => {
+        let originalURL = 'foobar';
+        let { url } = extractInfoFromXhrSetup((xhr, xhrSetupURL) => {}, originalURL);
+        url.should.equal(originalURL);
+    });
+
+    it('should return URL passed to "open" when called', () => {
+        let modifiedURL = "baz";
+        let originalURL = 'foobar';
+        let { url } = extractInfoFromXhrSetup((xhr, xhrSetupURL) => {
+            xhr.open('GET', modifiedURL);
+        }, originalURL);
+        url.should.equal(modifiedURL);
+    });
 });


### PR DESCRIPTION
Starting from hls.js 0.7.x, hls.js users can call `xhr.open('GET', url)` directly in xhr setup, which can be used to modify a fragment URL.
This PR allows us to get the modified URL in this case, and use it for the fragment request.