### PR TITLE
Add babel-runtime

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
     "presets": ["es2015"],
     "plugins": [
-        "add-module-exports"
+        "add-module-exports",
+        "transform-runtime"
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Fixed
+- Error on IE due to unsupported ES6 constructs
 
 ## [4.3.46] - 2017-09-20
 ### Added

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     ]
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "hls.js": "0.8.2",
     "lodash.assigninwith": "^4.0.7",
     "lodash.defaults": "4.0.1",
@@ -49,6 +50,7 @@
     "babel-eslint": "^6.0.4",
     "babel-loader": "^6.2.10",
     "babel-plugin-add-module-exports": "^0.2.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.3.0",


### PR DESCRIPTION
Fix error on IE due to unsupported ES6 constructs



