### PR TITLE
Remove Hls.js static function shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This changelog's template come from [keepachangelog.com](http://keepachangelog.c
 ## [Dev]
 
 ## [Unreleased]
+### Removed
+- Overrides to Hls.js static functions to block Safari.
 
 ## [4.3.55] - 2017-11-28
 ### Fixed

--- a/lib/hlsjs-p2p-bundle.js
+++ b/lib/hlsjs-p2p-bundle.js
@@ -2,10 +2,7 @@ import HlsjsP2PWrapper from './hlsjs-p2p-wrapper';
 import { inheritStaticPropertiesReadOnly } from './utils';
 import Hlsjs from 'hls.js';
 import extend from 'lodash.assigninwith';
-import UAParser from 'ua-parser-js';
 import defaults from 'lodash.defaults';
-
-const uaParserResult = (new UAParser()).getResult();
 
 /**
  * Shims Hls.js class. This de facto extends the class definition by ES6 spec, which means it inherits defined properties)
@@ -52,29 +49,5 @@ extend(StreamrootHlsjsBundle, Hlsjs);
 
 /* Inherit static read-only props (like Events etc.) */
 inheritStaticPropertiesReadOnly(StreamrootHlsjsBundle, Hlsjs);
-
-// Overrides of static methods. Has to be done _after_ calling `extend` !
-
-/**
- * We override `isSupported` to supply our own feature detection
- * @static
- * @override
- * @method
- */
-StreamrootHlsjsBundle.isSupported = function() {
-    var isSafari = uaParserResult.browser.name === "Safari";
-
-    return Hlsjs.isSupported() && !isSafari;
-};
-
-/**
- * We override `getBrowserName` to supply our own feature detection
- * @static
- * @override
- * @method
- */
-StreamrootHlsjsBundle.getBrowserName = function() {
-    return uaParserResult.browser.name;
-};
 
 export default StreamrootHlsjsBundle;


### PR DESCRIPTION
- Remove shim to reject `isSupported` for Safari.
- Remove injected `getBrowserName`.

This fixes `videojs-hlsjs-p2p-source-handler` always falling back to HTML5 on Safari because of the shimmed `isSupported` check. https://github.com/streamroot/videojs5-hlsjs-p2p-source-handler/blob/master/lib/videojs5-hlsjs-source-handler.js#L180
  